### PR TITLE
add option to remove duplicate sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ Then, you can e.g. use it in the following way from Python:
 ```
 import hammingdist
 
-# This accepts exactly the same two arguments as the stand-alone
-# executable: A fasta file and the maximum number of sequences to consider
-data = hammingdist.from_fasta("example.fasta", 100)
+# To import all sequences from a fasta file
+data = hammingdist.from_fasta("example.fasta")
+
+# To import only the first 100 sequences from a fasta file
+data = hammingdist.from_fasta("example.fasta", n=100)
+
+# To import all sequences and remove any duplicates
+data = hammingdist.from_fasta("example.fasta", remove_duplicates=True)
 
 # The distance data can be accessed point-wise, though looping over all distances might be quite inefficient
 print(data[14,42])
@@ -29,6 +34,10 @@ retrieval = hammingdist.from_csv("backup.csv")
 # It can also be written in lower triangular format (comma-delimited row-major, `lower-distance` Ripser format):
 data.dump_lower_triangular("lt.txt")
 retrieval = hammingdist.from_lower_triangular("lt.txt")
+
+# If the `remove_duplicates` option was used, the sequence indices can also be written.
+# For each input sequence, this prints the corresponding index in the output:
+data.dump_sequence_indices("indices.txt")
 
 # Finally, we can pass the data as a list of strings in Python:
 data = hammingdist.from_stringlist(["ACGTACGT", "ACGTAGGT", "ATTTACGT"])

--- a/include/hamming/hamming.hh
+++ b/include/hamming/hamming.hh
@@ -9,7 +9,7 @@ namespace hamming {
 
 DataSet from_stringlist(std::vector<std::string>&);
 DataSet from_csv(const std::string&);
-DataSet from_fasta(const std::string&, std::size_t n = 0);
+DataSet from_fasta(const std::string&, bool remove_duplicates = false, std::size_t n = 0);
 DataSet from_lower_triangular(const std::string&);
 
 }

--- a/include/hamming/hamming_types.hh
+++ b/include/hamming/hamming_types.hh
@@ -12,15 +12,17 @@ using DistIntType = uint8_t;
 
 struct DataSet
 {
-  DataSet(std::vector<std::string>&, bool clear_input_data = false);
+  DataSet(std::vector<std::string>&, bool clear_input_data = false, std::vector<std::size_t>&& indices = {});
   DataSet(const std::string&);
   DataSet(std::vector<DistIntType>&& distances);
   void dump(const std::string&);
   void dump_lower_triangular(const std::string&);
+  void dump_sequence_indices(const std::string&);
   int operator[](const std::array<std::size_t, 2>&) const;
 
   std::size_t nsamples;
   std::vector<DistIntType> result;
+  std::vector<std::size_t> sequence_indices{};
 };
 
 }

--- a/python/hammingdist.cc
+++ b/python/hammingdist.cc
@@ -14,12 +14,13 @@ PYBIND11_MODULE(hammingdist,m)
   py::class_<DataSet>(m, "DataSet")
       .def("dump", &DataSet::dump, "Dump distances matrix in csv format")
       .def("dump_lower_triangular", &DataSet::dump_lower_triangular, "Dump distances matrix in lower triangular format (comma-delimited, row-major)")
+      .def("dump_sequence_indices", &DataSet::dump_sequence_indices, "Dump row index in distances matrix for each input sequence")
       .def("__getitem__", &DataSet::operator[])
       .def_readonly("_distances", &DataSet::result);
 
   m.def("from_stringlist", &from_stringlist, "Creates a dataset from a list of strings");
   m.def("from_csv", &from_csv, "Creates a dataset by reading already computed distances from csv (full matrix expected)");
-  m.def("from_fasta", &from_fasta, py::arg("filename"), py::arg("n") = 0, "Creates a dataset by reading from a fasta file (assuming all sequences have equal length)");
+  m.def("from_fasta", &from_fasta, py::arg("filename"), py::arg("remove_duplicates") = false, py::arg("n") = 0, "Creates a dataset by reading from a fasta file (assuming all sequences have equal length)");
   m.def("from_lower_triangular", &from_lower_triangular, "Creates a dataset by reading already computed distances from lower triangular format");
 }
 


### PR DESCRIPTION
- add `remove_duplicates` option to `from_fasta()`
  - uses an unordered_map to identify duplicates & keep track of indices
  - increases pre-processing memory use: creates a copy of each unique sequence
- add `dump_sequence_indices()`
  - writes the row index in the distances matrix of each input sequence to a text file
- update README
- resolves #12
