### PR TITLE
add python tests & update CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,10 @@ jobs:
   build-wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      CIBW_TEST_REQUIRES: 'pytest numpy'
+      CIBW_TEST_COMMAND: 'pytest {project}/python/tests'
+      CIBW_TEST_SKIP: "pp*"
 
     strategy:
       matrix:
@@ -16,10 +20,7 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - uses: pypa/cibuildwheel@v1.11.1.post1
-      env:
-        CIBW_BEFORE_BUILD: python -m pip install cmake
-        CIBW_SKIP: "*-win32"
+    - uses: pypa/cibuildwheel@v2.0.0
 
     - uses: actions/upload-artifact@v2
       with:

--- a/python/tests/test_hammingdist.py
+++ b/python/tests/test_hammingdist.py
@@ -1,0 +1,63 @@
+import hammingdist
+import numpy as np
+
+def write_fasta_file(filename):
+    with open(filename, "w") as f:
+        f.write(">seq0\n")
+        f.write("ACGTGTCGTGTCGACGTGTCG\n")
+        f.write(">seq1\n")
+        f.write("ACGTGTCGTTTCGACGAGTCG\n")
+        f.write(">seq2\n")
+        f.write("ACGTGTCGTTTCGACGAGTCG\n")
+        f.write(">seq3\n")
+        f.write("ACGTGTCGTTTCGACGAGTCG\n")
+        f.write(">seq4\n")
+        f.write("ACGTGTCGTGTCGACGTGTCG\n")
+        f.write(">seq5\n")
+        f.write("ACGTGTCGTATCGACGTGTCG\n")
+
+def check_output_size(dat, n_in, n_out):
+    tmp_out_file = "out.txt"
+    
+    dat.dump(tmp_out_file)
+    dump = np.loadtxt(tmp_out_file, delimiter=',')
+    assert len(dump) == n_out
+    assert len(dump[0]) == n_out
+
+    dat.dump_lower_triangular(tmp_out_file)
+    with open(tmp_out_file) as f:
+        data = f.read().splitlines()
+    lt_first = np.fromstring(data[0], sep=',')
+    lt_last = np.fromstring(data[-1], sep=',')
+    assert len(lt_first) == 1
+    assert len(lt_last) == n_out - 1
+
+    dat.dump_sequence_indices(tmp_out_file)
+    indices = np.loadtxt(tmp_out_file, delimiter=',')
+    assert len(indices) == n_in
+    assert indices[0] == 0
+
+def test_from_fasta():
+    tmp_in_file = "in.txt"
+    write_fasta_file(tmp_in_file)
+
+    data = hammingdist.from_fasta(tmp_in_file)
+    check_output_size(data, 6, 6)
+
+    data = hammingdist.from_fasta(tmp_in_file, n=5)
+    check_output_size(data, 5, 5)
+
+    data = hammingdist.from_fasta(tmp_in_file, include_x=True)
+    check_output_size(data, 6, 6)
+
+    data = hammingdist.from_fasta(tmp_in_file, remove_duplicates=True)
+    check_output_size(data, 6, 3)
+
+    data = hammingdist.from_fasta(tmp_in_file, include_x=True, n=2)
+    check_output_size(data, 2, 2)
+
+    data = hammingdist.from_fasta(tmp_in_file, remove_duplicates=True, n=3)
+    check_output_size(data, 3, 2)
+
+    data = hammingdist.from_fasta(tmp_in_file, remove_duplicates=True, n=5, include_x=True)
+    check_output_size(data, 5, 2)

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,13 @@ from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from distutils.version import LooseVersion
 
+# Convert distutils Windows platform specifiers to CMake -A arguments
+PLAT_TO_CMAKE = {
+    "win32": "Win32",
+    "win-amd64": "x64",
+    "win-arm32": "ARM",
+    "win-arm64": "ARM64",
+}
 
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=''):
@@ -50,8 +57,7 @@ class CMakeBuild(build_ext):
 
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            if sys.maxsize > 2**32:
-                cmake_args += ['-A', 'x64']
+            cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
             build_args += ['--', '/m']
         else:
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]


### PR DESCRIPTION
- add minimal tests of from_fasta & dump* methods
- update cibuildwheel to 2.0.0
- update pybind11 to 2.7.0
- fix setup.py to build win32 wheels
- run python tests for each wheel
- resolves #13
